### PR TITLE
67 fix constant refresh in symptom screen

### DIFF
--- a/src/contexts/useCurrentEntityContext/index.tsx
+++ b/src/contexts/useCurrentEntityContext/index.tsx
@@ -5,8 +5,10 @@ import { IWorkResource } from "../../entities/IWorkResource";
 interface ICurrentSymptomContext {
   currentSymptom: IUserSymptom;
   currentWorkResource: IWorkResource;
+  currentSymptomPage: number;
   setCurrentWorkResource: (resource: IWorkResource) => void;
   setCurrentSymptom: (data: IUserSymptom) => void;
+  setCurrentSymptomPage: (page: number) => void;
 }
 
 interface ICurrentEntityContext extends ICurrentSymptomContext {}
@@ -17,14 +19,17 @@ export const CurrentEntityProvider = ({ children }) => {
   const [currentSymptom, setCurrentSymptom] = useState<IUserSymptom>(null);
   const [currentWorkResource, setCurrentWorkResource] =
     useState<IWorkResource>(null);
+  const [currentSymptomPage, setCurrentSymptomPage] = useState<number>(0);
 
   return (
     <CurrentEntityContext.Provider
       value={{
         currentSymptom,
         currentWorkResource,
+        currentSymptomPage,
         setCurrentSymptom,
         setCurrentWorkResource,
+        setCurrentSymptomPage,
       }}
     >
       {children}

--- a/src/hooks/useTrackedSymptoms/index.ts
+++ b/src/hooks/useTrackedSymptoms/index.ts
@@ -8,7 +8,8 @@ import { auth } from "../../config/firebase";
 import { useAuthenticationContext } from "../../contexts/useAuthenticationContext";
 import { SERVICES_LIMITS } from "../../config/services";
 import { getLimit } from "../../utils/getLimit";
-import { ISymptom } from "../../entities/ISymptom";
+import { useSymptomsContext } from "../../contexts/useSymptomsContext";
+import { useCurrentEntityContext } from "../../contexts/useCurrentEntityContext";
 
 const INIITAL_DATA: ITrackedSymptomsResponse = {
   count: 0,
@@ -16,18 +17,27 @@ const INIITAL_DATA: ITrackedSymptomsResponse = {
 };
 
 export const useTrackedSymptoms = ({
-  limit = SERVICES_LIMITS.UNLIMITED,
+  limit = SERVICES_LIMITS.EXPANDED_LIMIT,
   source = "all",
   currentPage = 1,
   skip = 0,
-  symptomList = [],
   config = [],
 }: IProps): IUseTrackedSymptomsResponse => {
   const { state } = useAuthenticationContext();
+  const { data: symptomList } = useSymptomsContext();
+  const { currentSymptomPage } = useCurrentEntityContext();
+
   const toast = useCustomToast();
 
   const { data, isFetching, refetch } = useQuery(
-    ["/tracked_symptoms", source, limit, currentPage, config],
+    [
+      "/tracked_symptoms",
+      source,
+      limit,
+      currentPage,
+      config,
+      currentSymptomPage,
+    ],
     async () => {
       const data = await services.get.trackedSymptoms({
         userId: auth?.currentUser?.uid,
@@ -51,13 +61,8 @@ export const useTrackedSymptoms = ({
       },
       initialData: INIITAL_DATA,
       refetchOnWindowFocus: false,
-      refetchInterval: 15000,
     }
   );
-
-  const refetchTrackedSymptoms = () => {
-    refetch();
-  };
 
   const trackedSymptoms = data?.results || [];
   const trackedSymptomsCount = data?.count || 0;
@@ -71,7 +76,7 @@ export const useTrackedSymptoms = ({
       isFetching: isFetching,
     },
     methods: {
-      handleOnRefetch: refetchTrackedSymptoms,
+      handleOnRefetch: refetch,
     },
   };
 };
@@ -94,5 +99,4 @@ interface IProps {
   source?: string;
   currentPage?: number;
   config?: any[];
-  symptomList?: ISymptom[];
 }

--- a/src/screens/ScreenAppAddSymptom/components/RatingSymptomSection/index.tsx
+++ b/src/screens/ScreenAppAddSymptom/components/RatingSymptomSection/index.tsx
@@ -42,7 +42,7 @@ export const RatingSymptomSection = ({
         />
 
         <Text fontSize={15} color="gray" fontStyle="italic">
-          This value must be less than the Target Severity
+          This value must be higher than the Target Severity
         </Text>
       </VStack>
 
@@ -55,7 +55,7 @@ export const RatingSymptomSection = ({
         />
 
         <Text fontSize={15} color="gray" fontStyle="italic">
-          This value must be higher than the Current Severity
+          This value must be lower than the Current Severity
         </Text>
       </VStack>
 

--- a/src/screens/ScreenAppAddSymptom/context/index.tsx
+++ b/src/screens/ScreenAppAddSymptom/context/index.tsx
@@ -17,8 +17,8 @@ import { auth } from "../../../config/firebase";
 import { ParamListBase, useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { ISymptomState } from "../../../entities/ISymptomState";
-import { findOption } from "../../../utils/findOption";
 import { createSeverityList } from "../../../utils/createSeverityList";
+import { useCurrentEntityContext } from "../../../contexts/useCurrentEntityContext";
 
 const AddSymptomContext = createContext({} as IAddSymptomContext);
 
@@ -43,9 +43,9 @@ export const AddSymptomProvider = ({ children }: IProviderProps) => {
   const { data: symptoms, isFetching: isFetchingSymptoms } =
     useSymptomsContext();
   const severityList = useSeverityRatings();
-  const { state: trackedSymptomsState, methods: trackedSymptomsMethods } =
-    useTrackedSymptoms({});
-
+  const { state: trackedSymptomsState } = useTrackedSymptoms({});
+  const { currentSymptomPage, setCurrentSymptomPage } =
+    useCurrentEntityContext();
   const [symptomState, setSymptomState] =
     useState<ISymptomState>(INITAL_SYMPTOM_STATE);
   const [formState, setFormState] =
@@ -124,8 +124,8 @@ export const AddSymptomProvider = ({ children }: IProviderProps) => {
         subTitle: `You added “${formState?.selectedSymptom?.name}” to your Tracked Symptoms list`,
       });
 
+      setCurrentSymptomPage(currentSymptomPage + 1);
       setFormState(INITAL_FORM_STATE);
-
       toast.successToast("Successfully added the new symptom");
       navigation.navigate("User Symptoms");
     } catch (e: any) {
@@ -141,6 +141,8 @@ export const AddSymptomProvider = ({ children }: IProviderProps) => {
 
   const isFetching = isFetchingSymptoms || trackedSymptomsState.isFetching;
 
+  console.log("CURRENT", formState?.currentSeverity.name);
+  console.log("TARGET", formState?.targetSeverity.name);
   return (
     <AddSymptomContext.Provider
       value={{
@@ -156,12 +158,12 @@ export const AddSymptomProvider = ({ children }: IProviderProps) => {
           isDisabled: isDisabled,
           targetSeverityList: createSeverityList({
             severityList: severityList,
-            selectedSeverity: Number(formState?.targetSeverity.name),
-            type: "current",
+            selectedSeverity: formState?.currentSeverity.name,
+            type: "target",
           }),
           currentSeverityList: createSeverityList({
             severityList: severityList,
-            selectedSeverity: Number(formState?.currentSeverity.name),
+            selectedSeverity: formState?.targetSeverity.name,
             type: "current",
           }),
         },

--- a/src/screens/ScreenAppSymptomGoal/context/index.tsx
+++ b/src/screens/ScreenAppSymptomGoal/context/index.tsx
@@ -152,8 +152,6 @@ export const SymptomGoalProvider = ({ children }: IProviderProps) => {
   const isPastDateReached = checkPastDate(state?.targetDate);
   const isButtonDisabled = findTodaysDateInScores(scores) || isPastDateReached;
 
-  console.log("VALUE", isButtonDisabled);
-
   const isFetching =
     isFetchingRatings ||
     resourcesState.isFetching ||

--- a/src/screens/ScreenAppSymptomGoal/context/index.tsx
+++ b/src/screens/ScreenAppSymptomGoal/context/index.tsx
@@ -177,7 +177,7 @@ export const SymptomGoalProvider = ({ children }: IProviderProps) => {
           limit: LIMIT,
           severityList: createSeverityList({
             severityList: severityList,
-            selectedSeverity: Number(currentSymptom?.currentSeverity),
+            selectedSeverity: String(currentSymptom?.currentSeverity),
             type: "target",
           }),
           averageScores: averageScores,

--- a/src/screens/ScreenAppSymptomGoal/index.tsx
+++ b/src/screens/ScreenAppSymptomGoal/index.tsx
@@ -94,7 +94,7 @@ const SymptomGoal = () => {
                   />
 
                   <Text.Regular color="gray" fontStyle="italic">
-                    This value must be higher than the Current Severity
+                    This value must be lower than the Current Severity
                   </Text.Regular>
                 </VStack>
 

--- a/src/screens/ScreenAppSymptoms/context/index.tsx
+++ b/src/screens/ScreenAppSymptoms/context/index.tsx
@@ -58,8 +58,7 @@ export const TrackedSymptomsProvider = ({ children }: IProviderProps) => {
   const SKIP = (state?.currentPage - 1) * LIMIT;
 
   // DATA
-  const { data: symptomList, isFetching: isFetchingSymptoms } =
-    useSymptomsContext();
+  const { data: symptomList } = useSymptomsContext();
 
   const { state: trackedSymptomsState, methods: trackedSymptomsMethods } =
     useTrackedSymptoms({
@@ -71,7 +70,6 @@ export const TrackedSymptomsProvider = ({ children }: IProviderProps) => {
         isSearchActive: state?.isSearchActive,
         search: searchState,
       }),
-      symptomList: symptomList,
     });
 
   const userSymptoms = formatUserSymptoms({
@@ -141,6 +139,7 @@ export const TrackedSymptomsProvider = ({ children }: IProviderProps) => {
       });
 
       trackedSymptomsMethods.handleOnRefetch();
+      toast.successToast("Successfuly removed this tracked symptom");
     } catch (e: any) {
       toast.errorToast("Failed to delete this tracked symptom.");
     } finally {

--- a/src/services/get-resources/index.ts
+++ b/src/services/get-resources/index.ts
@@ -12,8 +12,6 @@ import { resourcesAdapter } from "../../utils/resourcesAdapter";
 import { IOption } from "../../entities/IOption";
 
 export const getResources: IGetResourcesService = async (props) => {
-  console.log(props);
-
   const collectionName = `${props.name}_resources`;
   const referenceId = props?.name === "symptom" ? "symptomId" : "categoryId";
 

--- a/src/services/get-tracked-symptoms/index.ts
+++ b/src/services/get-tracked-symptoms/index.ts
@@ -11,7 +11,6 @@ import {
 } from "firebase/firestore";
 import { db } from "../../config/firebase";
 import { ISymptom } from "../../entities/ISymptom";
-import { formatDate } from "../../utils/formatDate";
 import { applyFilters } from "../../utils/applyFilters";
 import { sliceData } from "../../utils/sliceData";
 

--- a/src/utils/createSeverityList/index.ts
+++ b/src/utils/createSeverityList/index.ts
@@ -5,18 +5,20 @@ export const createSeverityList: ICreateSeverityListUtil = ({
   type,
   selectedSeverity,
 }) => {
+  if (selectedSeverity === "") return severityList;
+
   return severityList.filter((item) => {
     if (type === "current") {
-      return Number(item.name) > selectedSeverity;
+      return Number(item.name) > Number(selectedSeverity);
     }
 
-    return Number(item.name) < selectedSeverity;
+    return Number(item.name) < Number(selectedSeverity);
   });
 };
 
 interface IProps {
   severityList: IOption[];
-  selectedSeverity: number;
+  selectedSeverity: string;
   type: "current" | "target";
 }
 interface ICreateSeverityListUtil {


### PR DESCRIPTION
**Fix:**
- Edited message for current severity and target severity select list (higher and lower wrong way round)
- Adjusted createSeverityList util function as invalid options returned faulty list
- Removed refresh for symptoms 